### PR TITLE
Add missing angle-bracket to pre tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
 
 <p> Cloud 66 inspects your <code>Dockerfile</code> via your source code, so we’ll need to commit that into the code in your Git repository.</p>
 
-pre class="yaml">
+<pre class="yaml">
   <code>
     $ git add Dockerfile
 


### PR DESCRIPTION
Just a minor typo, but it's visible on the live site.